### PR TITLE
Update README.md to show real package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The only dependency that isn't automatically installed is MongoDb:
 
 OS/X ```brew install mongo```
 
-Linux ```sudo apt-get install mongo```
+Linux ```sudo apt-get install mongodb-server```
 
 Windows ```(no idea)```
 


### PR DESCRIPTION
On ubuntu vivid at least, the mongodb packages are called mongodb-server and mongodb-clients. mongodb-server pulls mongodb-clients so just installing mongodb-server probably is enough.
