### PR TITLE
Change git clone instructions for installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ documentation on their projects.  [Click to see a demo wiki.](http://tidalwave-d
 
 ## Dependencies
 
-The only dependency that isn't automatically installed is MongoDb:
+The dependencies that aren't automatically installed are npm and MongoDb:
 
 ### Installing MongoDB
 
-OS/X ```brew install mongo```
+OS/X ```brew install mongo && brew install npm```
 
-Linux ```sudo apt-get install mongodb-server```
+Linux ```sudo apt-get install mongodb-server npm```
 
 Windows ```(no idea)```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Linux ```sudo apt-get install mongodb-server```
 Windows ```(no idea)```
 
 ```
-git clone git@github.com:MisterTea/TidalWave.git TidalWave
+git clone https://github.com/MisterTea/TidalWave.git
 cd TidalWave
 npm start
 ```


### PR DESCRIPTION
git clone via ssh only works if ssh keys have been exchanged. Use the https based checkout in install instructions. Also, add npm to list of dependencies that need to be installed.
